### PR TITLE
add support for custom endpoints and move to ensure_packages for compati...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ define duplicity(
   $remove_older_than = undef,
   $sign_key_id = undef,
   $sign_key_passphrase = undef,
+  $custom_endpoint = undef,
 ) {
 
   include duplicity::params
@@ -48,6 +49,7 @@ define duplicity(
     remove_older_than      => $remove_older_than,
     sign_key_id            => $sign_key_id,
     sign_key_passphrase    => $sign_key_passphrase,
+    custom_endpoint        => $custom_endpoint,
   }
 
   $_hour = $hour ? {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -99,9 +99,9 @@ define duplicity::job(
     default => $remove_older_than,
   }
 
- if !($_cloud in [ 's3', 'cf', 'swift', 'file' ]) {
-   fail('$cloud required and at this time supports s3 for amazon s3 and cf for Rackspace cloud files')
- }
+  if !($_cloud in [ 's3', 'cf', 'swift', 'file' ]) {
+    fail('$cloud required and at this time supports s3 for amazon s3 and cf for Rackspace cloud files')
+  }
 
   case $ensure {
     'present' : {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -110,7 +110,7 @@ define duplicity::job(
         fail('directory parameter has to be passed if ensure != absent')
       }
 
-      if ($_bucket == undef) and ($custom_endpoint == undef) {
+      if !$_bucket and !$custom_endpoint {
         fail('You need to define a container/bucket name!')
       }
 
@@ -130,7 +130,7 @@ define duplicity::job(
     'file'  => [],
   }
 
-  if $custom_endpoint != undef {
+  if $custom_endpoint {
     $_target_url = $custom_endpoint
   }
   else {

--- a/manifests/monitored_job.pp
+++ b/manifests/monitored_job.pp
@@ -13,6 +13,7 @@ define duplicity::monitored_job(
   $full_if_older_than = undef,
   $pre_command = undef,
   $remove_older_than = undef,
+  $custom_endpoint = undef,
   $execution_timeout
 )
 {
@@ -35,6 +36,7 @@ define duplicity::monitored_job(
     full_if_older_than => $full_if_older_than,
     pre_command        => $pre_command,
     remove_older_than  => $remove_older_than,
+    custom_endpoint    => $custom_endpoint,
   }
 
   $_hour = $hour ? {

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,6 +1,4 @@
 class duplicity::packages {
   # Install the packages
-  package {
-    ['duplicity', 'python-boto', 'gnupg']: ensure => present
-  }
+  ensure_packages (['duplicity', 'python-boto', 'gnupg'])
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class duplicity::params(
   $minute                = $duplicity::defaults::minute,
   $full_if_older_than    = $duplicity::defaults::full_if_older_than,
   $remove_older_than     = undef,
+  $custom_endpoint       = undef,
   $job_spool = $duplicity::defaults::job_spool
 ) inherits duplicity::defaults {
 


### PR DESCRIPTION
...bility

This PR changes the package installation to use ensure_packages, helping to avoid clashes with other modules.

It also allows for the custom_endpoint parameter to be specified, however cloud still needs to be specified to get the environment variables right.