### PR TITLE
support skipping cron job generation so duplicity can be triggered by…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,9 @@ define duplicity(
       minute  => $_minute,
       hour    => $_hour,
     }
-  }
 
   File[$spoolfile]->Cron[$name]
+
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@ define duplicity(
   $sign_key_id = undef,
   $sign_key_passphrase = undef,
   $custom_endpoint = undef,
+  $create_cron = true,
 ) {
 
   include duplicity::params
@@ -62,12 +63,14 @@ define duplicity(
     default => $minute
   }
 
-  cron { $name :
-    ensure  => $ensure,
-    command => $spoolfile,
-    user    => 'root',
-    minute  => $_minute,
-    hour    => $_hour,
+  if $create_cron {
+    cron { $name :
+      ensure  => $ensure,
+      command => $spoolfile,
+      user    => 'root',
+      minute  => $_minute,
+      hour    => $_hour,
+    }
   }
 
   File[$spoolfile]->Cron[$name]


### PR DESCRIPTION
… other means

Postgresql supports running a command after WAL file creation then only recycling the file after this command has successfully completed. With this PR we can now skip the cron job generation and trigger duplicity backups, which goes nicely with Postgresql.