### PR TITLE
update duplicity module to support setting the resultant script owner

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ define duplicity(
   $sign_key_passphrase = undef,
   $custom_endpoint = undef,
   $create_cron = true,
+  $script_owner = 'root',
 ) {
 
   include duplicity::params
@@ -35,6 +36,7 @@ define duplicity(
   duplicity::job { $name :
     ensure                 => $ensure,
     spoolfile              => $spoolfile,
+    script_owner           => $script_owner,
     directory              => $directory,
     bucket                 => $bucket,
     dest_id                => $dest_id,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,9 @@ define duplicity(
   $custom_endpoint = undef,
   $create_cron = true,
   $script_owner = 'root',
-) {
+  $script_permissions = '0700',
+  $script_group_owner = 'root',
+  ) {
 
   include duplicity::params
   include duplicity::packages
@@ -37,6 +39,8 @@ define duplicity(
     ensure                 => $ensure,
     spoolfile              => $spoolfile,
     script_owner           => $script_owner,
+    script_permissions     => $script_permissions,
+    script_group_owner     => $script_group_owner,
     directory              => $directory,
     bucket                 => $bucket,
     dest_id                => $dest_id,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -2,6 +2,8 @@ define duplicity::job(
   $ensure = 'present',
   $spoolfile,
   $script_owner,
+  $script_permissions,
+  $script_group_owner,
   $directory = undef,
   $bucket = undef,
   $dest_id = undef,
@@ -152,7 +154,8 @@ define duplicity::job(
     ensure  => $ensure,
     content => template('duplicity/file-backup.sh.erb'),
     owner   => $script_owner,
-    mode    => '0700',
+    mode    => $script_permissions,
+    group   => $script_group_owner,
   }
 
   if $_encrypt_key_id {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -1,6 +1,7 @@
 define duplicity::job(
   $ensure = 'present',
   $spoolfile,
+  $script_owner,
   $directory = undef,
   $bucket = undef,
   $dest_id = undef,
@@ -150,7 +151,7 @@ define duplicity::job(
   file { $spoolfile:
     ensure  => $ensure,
     content => template('duplicity/file-backup.sh.erb'),
-    owner   => 'root',
+    owner   => $script_owner,
     mode    => '0700',
   }
 


### PR DESCRIPTION
Normally the duplicity backup script that is created by this module is owned by root. With this PR that script can now be owned by anyone, you've just gotta supply script_owner.
